### PR TITLE
Add support for sending Goerli Eth to users 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 **/.idea/**
 bazel-*
+.ijwb/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 
@@ -12,9 +12,11 @@ go_library(
     name = "go_default_library",
     srcs = [
         "block.go",
+        "channels.go",
         "commands.go",
         "current.go",
         "food.go",
+        "goerli.go",
         "help.go",
         "main.go",
         "random.go",
@@ -26,7 +28,13 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_bwmarrin_discordgo//:go_default_library",
+        "@com_github_ethereum_go_ethereum//accounts/keystore:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_ethereum_go_ethereum//core/types:go_default_library",
+        "@com_github_ethereum_go_ethereum//crypto:go_default_library",
+        "@com_github_ethereum_go_ethereum//ethclient:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_prysm//shared/params:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -93,8 +101,8 @@ container_image(
 
 container_push(
     name = "push_image",
-    image = ":go_image",
     format = "Docker",
+    image = ":go_image",
     registry = "gcr.io",
     repository = "prysmaticlabs/prysmbot",
     tag = "latest",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,23 +11,23 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
     ],
-    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
 )
 
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
     ],
-    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -140,6 +140,13 @@ go_repository(
 )
 
 go_repository(
+    name = "in_gopkg_urfave_cli_v2",
+    importpath = "gopkg.in/urfave/cli.v2",
+    sum = "h1:OvXt/p4cdwNl+mwcWMq/AxaKFkhdxcjx+tx+qf4EOvY=",
+    version = "v2.0.0-20190806201727-b62605953717",
+)
+
+go_repository(
     name = "com_github_gorilla_websocket",
     importpath = "github.com/gorilla/websocket",
     sum = "h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=",
@@ -158,4 +165,59 @@ go_repository(
     importpath = "golang.org/x/text",
     sum = "h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=",
     version = "v0.3.2",
+)
+
+go_repository(
+    name = "com_github_deckarep_golang_set",
+    commit = "cbaa98ba5575e67703b32b4b19f73c91f3c4159e",  # v1.7.1
+    importpath = "github.com/deckarep/golang-set",
+)
+
+go_repository(
+    name = "com_github_google_uuid",
+    commit = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4",  # v1.1.1
+    importpath = "github.com/google/uuid",
+)
+
+go_repository(
+    name = "com_github_aristanetworks_goarista",
+    commit = "728bce664cf5dfb921941b240828f989a2c8f8e3",
+    importpath = "github.com/aristanetworks/goarista",
+)
+
+go_repository(
+    name = "com_github_btcsuite_btcd",
+    commit = "306aecffea325e97f513b3ff0cf7895a5310651d",
+    importpath = "github.com/btcsuite/btcd",
+)
+
+go_repository(
+    name = "com_github_rs_cors",
+    commit = "db0fe48135e83b5812a5a31be0eea66984b1b521",  # v1.7.0
+    importpath = "github.com/rs/cors",
+)
+
+go_repository(
+    name = "com_github_pborman_uuid",
+    commit = "8b1b92947f46224e3b97bb1a3a5b0382be00d31e",  # v1.2.0
+    importpath = "github.com/pborman/uuid",
+)
+
+go_repository(
+    name = "com_github_go_stack_stack",
+    commit = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a",  # v1.8.0
+    importpath = "github.com/go-stack/stack",
+)
+
+go_repository(
+    name = "com_github_ethereum_go_ethereum",
+    commit = "0beb54b2147b3473a4c55e5ce6f02643ce403b14",
+    importpath = "github.com/ethereum/go-ethereum",
+    # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
+    # a fork that has resolved these issues by disabling HID/USB support and
+    # some manual fixes for c imports in the crypto package. This is forked
+    # branch should be updated from time to time with the latest go-ethereum
+    # code.
+    remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
+    vcs = "git",
 )

--- a/channels.go
+++ b/channels.go
@@ -1,0 +1,8 @@
+package main
+
+var (
+	personalTesting = "701148358445760573"
+	prysmInternal = "691473296696410164"
+	prysmGeneral = "476588476393848832"
+	prysmRandom = "696886109589995521"
+)

--- a/goerli.go
+++ b/goerli.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"github.com/pkg/errors"
+	"math/big"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var depositAmount = 32
+var minimumRequestAmt = depositAmount + 1
+var etherInWei = big.NewInt(1000000000000000000)
+var maxETHToSend = 170
+
+var addr common.Address
+var key *ecdsa.PrivateKey
+var web3 *ethclient.Client
+
+func SendGoeth(parameters []string) (string, error) {
+	if len(parameters) > 2 {
+		return "This command requires 2 parameters", nil
+	}
+	address := parameters[0]
+	var amountETH int
+	var err error
+	if len(parameters) == 2 {
+		amountETH, err = strconv.Atoi(parameters[1])
+		if err != nil {
+			return "", errors.Wrap(err, "could not parse")
+		}
+	} else {
+		amountETH = maxETHToSend
+	}
+	if amountETH % depositAmount == 0 {
+		if amountETH == depositAmount {
+			amountETH = minimumRequestAmt
+		} else {
+			// Give an extra eth for gas fees if they request a perfect multiple.
+			amountETH += 1
+		}
+	}
+	if amountETH > maxETHToSend {
+		return fmt.Sprintf("Sorry! Only up to %d GoETH at a time!", maxETHToSend), nil
+	}
+	if !common.IsHexAddress(address) {
+		return "Please enter a valid address!", nil
+	}
+	toAddress := common.HexToAddress(address)
+
+	bal, err := web3.BalanceAt(context.Background(), addr, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "could not get account balance")
+	}
+
+	minBalance := big.NewInt(int64(amountETH))
+	minBalance.Mul(minBalance, etherInWei)
+	if bal.Cmp(minBalance) < 0 {
+		return "Goerli Wallet is out of Ether! <@118185622543269890>", nil
+	}
+	nonce, err := web3.PendingNonceAt(context.Background(), addr)
+	if err != nil {
+		return "", err
+	}
+	value := big.NewInt(0) // in wei (1 eth)
+	value.Mul(etherInWei, big.NewInt(int64(amountETH)))
+	gasLimit := uint64(21000) // in units
+	gasPrice, err := web3.SuggestGasPrice(context.Background())
+	if err != nil {
+		return "", err
+	}
+	tx := types.NewTransaction(nonce, toAddress, value, gasLimit, gasPrice, nil)
+	chainID, err := web3.NetworkID(context.Background())
+	if err != nil {
+		return "", err
+	}
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), key)
+	if err != nil {
+		return "", err
+	}
+	err = web3.SendTransaction(context.Background(), signedTx)
+	if err != nil {
+		return "", errors.Wrap(err, "could not send")
+	}
+	return fmt.Sprintf("Sent! https://goerli.etherscan.io/tx/%s", signedTx.Hash().String()), nil
+}
+
+func initWallet() error {
+	var err error
+	if Password != "" {
+		goerliKey, err := keystore.DecryptKey([]byte(EncryptedPriv), Password /*password*/)
+		if err != nil {
+			return err
+		}
+		key = goerliKey.PrivateKey
+		addr = goerliKey.Address
+	} else {
+		key, err = crypto.HexToECDSA(EncryptedPriv)
+		if err != nil {
+			return err
+		}
+		publicKey := key.Public()
+		publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+		if !ok {
+			log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
+		}
+
+		addr = crypto.PubkeyToAddress(*publicKeyECDSA)
+	}
+
+	web3, err = ethclient.Dial(RPCUrl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This allows Prysmbot to send goerli eth to users in pre-defined channels. 

The bot is set to send a max of 170 goeth per request, this can be combined with discords slow mode to restrict requests to once per user every 6 hours.